### PR TITLE
Version 1.1

### DIFF
--- a/iNaturalistGallery.php
+++ b/iNaturalistGallery.php
@@ -138,10 +138,10 @@ class iNaturalistGallery {
 
         // Summary line - format differently based on whether it's standard taxonomy or provisional
         $count = $data['total_results'] ?? count($data['results']);
-        
         if ($foundBy === "Provisional Species Name") {
             // New format for provisional species names
-            $summary = "<p style='font-weight:bold;'>Searched for iNaturalist Provisional Species Name <em>$speciesName</em>; total results: <strong>$count</strong>.</p>";
+            $safeName = htmlspecialchars($speciesName, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $summary  = "<p style='font-weight:bold;'>Searched for iNaturalist Provisional Species Name <em>{$safeName}</em>; total results: <strong>{$count}</strong>.</p>";
         } else {
             // Keep existing format for standard taxonomy
             $summary = "<p style='font-weight:bold;'>Searched iNaturalist $foundBy for <em>$speciesName</em> with ITS sequence; total results: <strong>$count</strong>.</p>";

--- a/iNaturalistGallery.php
+++ b/iNaturalistGallery.php
@@ -114,11 +114,11 @@ class iNaturalistGallery {
         // If standard taxonomy lookup failed or was skipped, try provisional name search
         if (empty($data['results'])) {
             // Handle field:Provisional Species Name parameter properly
-            $provisionalFieldKey = urlencode('field:Provisional Species Name');
-            $provisionalFieldValue = urlencode($speciesName);
+            // key MUST stay literal, only the value is encoded
+            $provisionalFieldKey   = 'field:Provisional%20Species%20Name';
+            $provisionalFieldValue = rawurlencode($speciesName);
             $queryString = "order_by=id&order=desc&page=1&spam=false&{$provisionalFieldKey}={$provisionalFieldValue}&per_page=100&return_bounds=true";
             $url = "$apiUrl?$queryString";
-
             self::logDebug("Checking Provisional Species Name: '$speciesName'");
             self::logDebug("Provisional API URL: $url");
 

--- a/iNaturalistGallery.php
+++ b/iNaturalistGallery.php
@@ -13,10 +13,11 @@ $wgExtensionCredits['parserhook'][] = [
     'url' => 'https://www.mediawiki.org/wiki/Extension:iNaturalistGallery',
 ];
 
+// Register the parser hook
 $wgHooks['ParserFirstCallInit'][] = 'iNaturalistGallery::onParserFirstCallInit';
 
 class iNaturalistGallery {
-    private static $logFile = '/var/www/vhosts/mycomap.org/wiki/logs/inat_debug.log';
+    private static $logFile = '/tmp/inat_debug.log';
 
     /****
      * Registers the <iNaturalistGallery> parser hook with the MediaWiki parser.

--- a/iNaturalistGallery.php
+++ b/iNaturalistGallery.php
@@ -9,7 +9,7 @@ $wgExtensionCredits['parserhook'][] = [
     'name' => 'iNaturalistGallery',
     'author' => 'Matej Franceskin',
     'description' => 'Displays an iNaturalist gallery based on a species name (standard or provisional).',
-    'version' => '1.1',
+    'version' => '1.2',
     'url' => 'https://www.mediawiki.org/wiki/Extension:iNaturalistGallery',
 ];
 
@@ -17,7 +17,8 @@ $wgExtensionCredits['parserhook'][] = [
 $wgHooks['ParserFirstCallInit'][] = 'iNaturalistGallery::onParserFirstCallInit';
 
 class iNaturalistGallery {
-    private static $logFile = '/tmp/inat_debug.log';
+    private static $logFile = '/var/www/vhosts/mycomap.org/wiki/logs/inat_debug.log';
+    private static $galleryCounter = 0;
 
     /****
      * Registers the <iNaturalistGallery> parser hook with the MediaWiki parser.
@@ -50,45 +51,28 @@ class iNaturalistGallery {
      * @return string HTML markup for the gallery or an error message if no observations are found.
      */
     public static function renderGallery($input, array $args, Parser $parser, PPFrame $frame) {
+        // Get species name from tag or page title
         $speciesName = isset($args['species']) ? $args['species'] : $parser->getTitle()->getText();
         if (empty($speciesName)) {
             return '<div class="error">Error: No species name provided.</div>';
         }
+        
+        // Increment counter to get a unique gallery ID
+        self::$galleryCounter++;
+        $galleryId = 'inat_gallery_' . self::$galleryCounter . '_' . rand(1000, 9999);
+        
+        self::logDebug("Rendering gallery with ID: $galleryId for species: $speciesName");
 
         $speciesName = str_replace('_', ' ', $speciesName);
         $apiUrl = 'https://api.inaturalist.org/v1/observations';
         $foundBy = '';
         $data = null;
-        $fieldName = 'field:Provisional Species Name'; // Default to provisional field name
+        $taxonId = null;
 
-        // If name contains quotes it's provisional - skip standard taxonomy search
-        if (strpos($speciesName, "'") !== false || strpos($speciesName, '"') !== false) {
-            $foundBy = "Provisional Species Name";
-            // Try the iNaturalist observation field Provisional Species Name 
-            $params = [
-                'order_by' => 'id',
-                'order' => 'desc',
-                'page' => 1,
-                'spam' => 'false',
-                'field:Provisional Species Name' => $speciesName,
-                'per_page' => 24,
-                'return_bounds' => 'true',
-            ];
-            $queryString = http_build_query($params);
-            $url = "$apiUrl?$queryString";
+        // If name contains quotes it's definitely provisional - skip standard taxonomy search
+        $isProvisionalNameByQuotes = (strpos($speciesName, "'") !== false || strpos($speciesName, '"') !== false);
 
-            self::logDebug("Fallback to Provisional Species Name: '$speciesName'");
-            self::logDebug("Provisional API URL: $url");
-
-            $response = file_get_contents($url);
-            if ($response !== false) {
-                $data = json_decode($response, true);
-                if (!empty($data['results'])) {
-                    $foundBy = "Provisional Species Name";
-                    $fieldName = 'field:Provisional Species Name'; // Set the field for provisional name
-                }
-            }
-        } else {
+        if (!$isProvisionalNameByQuotes) {
             // Step 1: Try to get taxon_id from the iNaturalist standard taxonomy
             $taxonSearchUrl = 'https://api.inaturalist.org/v1/taxa?q=' . urlencode($speciesName);
             self::logDebug("Standard taxonomy search for species: '$speciesName'");
@@ -107,7 +91,7 @@ class iNaturalistGallery {
                         'spam' => 'false',
                         'taxon_id' => $taxonId,
                         'field:DNA Barcode ITS' => '',
-                        'per_page' => 24,
+                        'per_page' => 200,
                         'return_bounds' => 'true',
                     ];
                     $queryString = http_build_query($params);
@@ -127,59 +111,239 @@ class iNaturalistGallery {
             }
         }
 
+        // If standard taxonomy lookup failed or was skipped, try provisional name search
+        if (empty($data['results'])) {
+            // Handle field:Provisional Species Name parameter properly
+            $provisionalFieldKey = urlencode('field:Provisional Species Name');
+            $provisionalFieldValue = urlencode($speciesName);
+            $queryString = "order_by=id&order=desc&page=1&spam=false&{$provisionalFieldKey}={$provisionalFieldValue}&per_page=100&return_bounds=true";
+            $url = "$apiUrl?$queryString";
+
+            self::logDebug("Checking Provisional Species Name: '$speciesName'");
+            self::logDebug("Provisional API URL: $url");
+
+            $response = file_get_contents($url);
+            if ($response !== false) {
+                $data = json_decode($response, true);
+                if (!empty($data['results'])) {
+                    $foundBy = "Provisional Species Name";
+                    $fieldName = 'field:Provisional Species Name';
+                }
+            }
+        }
+
         if (empty($data['results'])) {
             return '<div class="error">No observations found for the given species name.</div>';
         }
 
-        // Summary line
+        // Summary line - format differently based on whether it's standard taxonomy or provisional
         $count = $data['total_results'] ?? count($data['results']);
-        $summary = "<p style='font-weight:bold;'>Searched iNaturalist $foundBy for <em>$speciesName</em> with ITS sequence; total results: <strong>$count</strong>.</p>";
-
-        // Add message if more than 24 results
-        if ($count > 24) {
-            $summary .= "<p>Showing 24 results out of $count.</p>";
+        
+        if ($foundBy === "Provisional Species Name") {
+            // New format for provisional species names
+            $summary = "<p style='font-weight:bold;'>Searched for iNaturalist Provisional Species Name <em>$speciesName</em>; total results: <strong>$count</strong>.</p>";
+        } else {
+            // Keep existing format for standard taxonomy
+            $summary = "<p style='font-weight:bold;'>Searched iNaturalist $foundBy for <em>$speciesName</em> with ITS sequence; total results: <strong>$count</strong>.</p>";
         }
 
-        // Build gallery with only the first 24 results
-        $html = $summary;
-        $html .= '<div class="inat-gallery" style="display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px;">';
-
-        $limit = min(24, count($data['results']));
-        for ($i = 0; $i < $limit; $i++) {
-            $observation = $data['results'][$i];
-            if (isset($observation['photos'][0])) {
-                $photo = $observation['photos'][0];
-                $photoUrl = str_replace('square', 'small', $photo['url']);
-                $taxonName = isset($observation['taxon']['name']) ? $observation['taxon']['name'] : 'Unknown Taxon';
-                $observationUri = $observation['uri'];
-
-                $html .= '<div style="text-align: center;">';
-                $html .= '<div style="width: 100%; padding-top: 100%; position: relative; overflow: hidden; border-radius: 5px;">';
-                $html .= "<img src=\"$photoUrl\" alt=\"$taxonName\" style=\"position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover;\">";
-                $html .= '</div>';
-                $html .= "<a href=\"$observationUri\" target=\"_blank\" style=\"display: block; margin-top: 5px; text-decoration: none; color: #007BFF;\">$taxonName</a>";
-                $html .= '</div>';
+        // Build collections of photos - one per observation and all photos
+        $regularPhotos = [];
+        $allPhotos = [];
+        $totalPhotoCount = 0;
+        
+        // Process all observations
+        foreach ($data['results'] as $observation) {
+            if (isset($observation['photos']) && is_array($observation['photos'])) {
+                $numPhotos = count($observation['photos']);
+                $totalPhotoCount += $numPhotos;
+                
+                // Log observation details
+                self::logDebug("Observation ID: {$observation['id']} has $numPhotos photos");
+                
+                // Add first photo to regular collection
+                if (!empty($observation['photos'])) {
+                    $photo = $observation['photos'][0];
+                    $photoUrl = str_replace('square', 'original', $photo['url']);
+                    $smallPhotoUrl = str_replace('square', 'medium', $photo['url']);  // Use medium for regular view
+                    $taxonName = isset($observation['taxon']['name']) ? $observation['taxon']['name'] : 'Unknown Taxon';
+                    $observationUri = $observation['uri'];
+                    
+                    $regularPhotos[] = [
+                        'url' => $smallPhotoUrl,  // Medium size for regular view
+                        'original_url' => $photoUrl,  // Original size for lightbox
+                        'taxon' => $taxonName,
+                        'uri' => $observationUri,
+                        'observation_id' => $observation['id']
+                    ];
+                    
+                    self::logDebug("Added first photo from observation {$observation['id']} to regular display: $smallPhotoUrl");
+                }
+                
+                // Add all photos to all photos collection
+                foreach ($observation['photos'] as $index => $photo) {
+                    $photoUrl = str_replace('square', 'original', $photo['url']);
+                    $smallPhotoUrl = str_replace('square', 'medium', $photo['url']);  // Use medium for thumbnails
+                    $taxonName = isset($observation['taxon']['name']) ? $observation['taxon']['name'] : 'Unknown Taxon';
+                    $observationUri = $observation['uri'];
+                    
+                    $allPhotos[] = [
+                        'url' => $smallPhotoUrl,  // Medium size for gallery
+                        'original_url' => $photoUrl,  // Original size for lightbox
+                        'taxon' => $taxonName,
+                        'display_name' => $taxonName . " (Photo " . ($index + 1) . " of $numPhotos)",
+                        'uri' => $observationUri,
+                        'observation_id' => $observation['id'],
+                        'photo_index' => $index + 1,
+                        'total_photos' => $numPhotos
+                    ];
+                    
+                    self::logDebug("Added photo " . ($index + 1) . " from observation {$observation['id']} to all photos collection: $smallPhotoUrl");
+                }
             }
         }
+        
+        self::logDebug("Total photos found: $totalPhotoCount");
+        self::logDebug("Number of photos in regular mode: " . count($regularPhotos));
+        self::logDebug("Number of photos in all photos mode: " . count($allPhotos));
 
-        $html .= '</div>';
+        // Display status texts
+        $regularStatusText = "Showing one photo from each of " . count($regularPhotos) . " observations. These observations contain a total of $totalPhotoCount photos.";
+        
+        if ($foundBy === "Provisional Species Name") {
+            $allPhotosStatusText = "Showing $totalPhotoCount photos of $speciesName.";
+            $allPhotosLinkText = "Show photos of $speciesName";
+        } else {
+            $allPhotosStatusText = "Showing $totalPhotoCount photos of sequenced observations of $speciesName.";
+            $allPhotosLinkText = "Show photos of sequenced observations of $speciesName";
+        }
 
-        // Link to full list with conditional text and field
+        // Build gallery HTML
+        $html = $summary;
+        
+        // Status text (changes based on current view)
+        $html .= "<p id=\"{$galleryId}_status\">$regularStatusText</p>";
+        
+        // Regular gallery container (one photo per observation) - visible by default
+        $html .= "<div id=\"{$galleryId}_regular_container\" style=\"display: block;\">";
+        
+        // Regular gallery (one photo per observation) - 4 columns for regular view
+        $html .= "<div id=\"{$galleryId}_regular\" class=\"inat-gallery\" style=\"display: grid; grid-template-columns: repeat(4, 1fr); gap: 15px;\">";
+        foreach ($regularPhotos as $index => $photo) {
+            $html .= '<div class="gallery-item" style="text-align: center;">';
+            $html .= '<div style="width: 100%; padding-top: 100%; position: relative; overflow: hidden; border-radius: 5px;">';
+            $html .= "<img src=\"{$photo['url']}\" data-original=\"{$photo['original_url']}\" alt=\"{$photo['taxon']}\" style=\"position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain; background-color: #f8f8f8;\">";
+            $html .= '</div>';
+            $html .= "<a href=\"{$photo['uri']}\" target=\"_blank\" style=\"display: block; margin-top: 5px; text-decoration: none; color: #007BFF;\">{$photo['taxon']}</a>";
+            $html .= '</div>';
+        }
+        $html .= "</div>";
+        $html .= "</div>";
+        
+        // All photos container - initially hidden
+        $html .= "<div id=\"{$galleryId}_all_container\" style=\"display: none;\">";
+        
+        // All photos gallery - 3 columns for all photos view to make them larger
+        $html .= "<div id=\"{$galleryId}_all\" class=\"inat-gallery\" style=\"display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px;\">";
+        foreach ($allPhotos as $index => $photo) {
+            $html .= '<div class="gallery-item" style="text-align: center;">';
+            $html .= '<div style="width: 100%; padding-top: 100%; position: relative; overflow: hidden; border-radius: 5px;">';
+            $html .= "<img src=\"{$photo['url']}\" data-original=\"{$photo['original_url']}\" alt=\"{$photo['display_name']}\" style=\"position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain; background-color: #f8f8f8;\">";
+            $html .= '</div>';
+            $html .= "<a href=\"{$photo['uri']}\" target=\"_blank\" style=\"display: block; margin-top: 5px; text-decoration: none; color: #007BFF;\">{$photo['display_name']}</a>";
+            $html .= '</div>';
+        }
+        $html .= "</div>";
+        $html .= "</div>";
+
+        // Link to iNaturalist
         $speciesNameEncoded = urlencode($speciesName);
-        $fullUrl = '';
-
         if ($foundBy === "standard taxonomy (taxon_id: $taxonId)") {
             $fullUrl = "https://www.inaturalist.org/observations?subview=map&taxon_id=$taxonId&field:DNA%20Barcode%20ITS=";
             $linkText = "Sequenced iNaturalist observations for $speciesName";
         } else {
-            $fullUrl = "https://www.inaturalist.org/observations?verifiable=any&place_id=any&$fieldName=$speciesNameEncoded";
+            $provisionalFieldUrlPart = urlencode('field:Provisional Species Name');
+            $fullUrl = "https://www.inaturalist.org/observations?verifiable=any&place_id=any&{$provisionalFieldUrlPart}={$speciesNameEncoded}";
             $linkText = "iNaturalist observations for provisional species name $speciesName";
         }
 
+        // Add links section
         $html .= '<div style="text-align: center; margin-top: 20px;">';
         $html .= "<a href=\"$fullUrl\" target=\"_blank\" style=\"text-decoration: none; color: #007BFF; font-weight: bold;\">$linkText</a>";
+        $html .= "<br><br>";
+        
+        // Toggle buttons with more reliable onclick handlers
+        $html .= "<button id=\"{$galleryId}_show_all\" style=\"background: none; border: none; color: #007BFF; text-decoration: underline; cursor: pointer; font-weight: bold; padding: 0;\">$allPhotosLinkText</button>";
+        $html .= "<button id=\"{$galleryId}_show_regular\" style=\"background: none; border: none; color: #007BFF; text-decoration: underline; cursor: pointer; font-weight: bold; padding: 0; display: none;\">Show one photo per observation</button>";
         $html .= '</div>';
-
+        
+        // Better JavaScript toggle implementation
+        $parser->getOutput()->addHeadItem("
+            <script type=\"text/javascript\">
+            (function() {
+                // Function to initialize gallery once DOM is loaded
+                function initGallery_$galleryId() {
+                    console.log('Initializing gallery: $galleryId');
+                    
+                    // Get DOM elements
+                    var showAllBtn = document.getElementById('{$galleryId}_show_all');
+                    var showRegularBtn = document.getElementById('{$galleryId}_show_regular');
+                    var regularContainer = document.getElementById('{$galleryId}_regular_container');
+                    var allContainer = document.getElementById('{$galleryId}_all_container');
+                    var statusText = document.getElementById('{$galleryId}_status');
+                    
+                    // Check if elements exist
+                    if (!showAllBtn || !showRegularBtn || !regularContainer || !allContainer || !statusText) {
+                        console.error('Gallery elements not found for $galleryId');
+                        return;
+                    }
+                    
+                    // Function to show all photos
+                    function showAllPhotos() {
+                        console.log('Showing all photos for $galleryId');
+                        regularContainer.style.display = 'none';
+                        allContainer.style.display = 'block';
+                        showAllBtn.style.display = 'none';
+                        showRegularBtn.style.display = 'inline';
+                        statusText.textContent = '$allPhotosStatusText';
+                        return false;
+                    }
+                    
+                    // Function to show regular gallery
+                    function showRegularPhotos() {
+                        console.log('Showing regular gallery for $galleryId');
+                        allContainer.style.display = 'none';
+                        regularContainer.style.display = 'block';
+                        showRegularBtn.style.display = 'none';
+                        showAllBtn.style.display = 'inline';
+                        statusText.textContent = '$regularStatusText';
+                        return false;
+                    }
+                    
+                    // Add event listeners
+                    showAllBtn.addEventListener('click', function(e) {
+                        e.preventDefault();
+                        showAllPhotos();
+                    });
+                    
+                    showRegularBtn.addEventListener('click', function(e) {
+                        e.preventDefault();
+                        showRegularPhotos();
+                    });
+                    
+                    console.log('Gallery $galleryId initialized');
+                }
+                
+                // Initialize when DOM is ready
+                if (document.readyState === 'loading') {
+                    document.addEventListener('DOMContentLoaded', initGallery_$galleryId);
+                } else {
+                    initGallery_$galleryId();
+                }
+            })();
+            </script>
+        ", 'inaturalist-gallery-' . $galleryId);
+        
         return $html;
     }
 }

--- a/iNaturalistGallery.php
+++ b/iNaturalistGallery.php
@@ -18,15 +18,36 @@ $wgHooks['ParserFirstCallInit'][] = 'iNaturalistGallery::onParserFirstCallInit';
 class iNaturalistGallery {
     private static $logFile = '/var/www/vhosts/mycomap.org/wiki/logs/inat_debug.log';
 
+    /****
+     * Registers the <iNaturalistGallery> parser hook with the MediaWiki parser.
+     *
+     * @return bool True on successful hook registration.
+     */
     public static function onParserFirstCallInit(Parser $parser) {
         $parser->setHook('iNaturalistGallery', [self::class, 'renderGallery']);
         return true;
     }
 
+    /****
+     * Writes a timestamped debug message to the extension's log file.
+     *
+     * @param string $message The debug message to log.
+     */
     private static function logDebug($message) {
         error_log(date('[Y-m-d H:i:s] ') . $message . "\n", 3, self::$logFile);
     }
 
+    /**
+     * Renders an iNaturalist photo gallery for a given species name, supporting both standard taxonomy and provisional species names.
+     *
+     * Determines the search method based on the presence of quotes in the species name: if quotes are present, searches iNaturalist observations by the "Provisional Species Name" field; otherwise, attempts to resolve the species to a taxon ID and searches for observations with a DNA Barcode ITS field. Displays up to 24 observation photos in a grid, includes a summary of the search, and provides a link to the full list of relevant iNaturalist observations.
+     *
+     * @param mixed $input Unused input parameter from the parser hook.
+     * @param array $args Arguments passed to the parser tag, including an optional 'species' key.
+     * @param Parser $parser MediaWiki parser instance.
+     * @param PPFrame $frame Parser frame.
+     * @return string HTML markup for the gallery or an error message if no observations are found.
+     */
     public static function renderGallery($input, array $args, Parser $parser, PPFrame $frame) {
         $speciesName = isset($args['species']) ? $args['species'] : $parser->getTitle()->getText();
         if (empty($speciesName)) {

--- a/iNaturalistGallery.php
+++ b/iNaturalistGallery.php
@@ -1,89 +1,136 @@
 <?php
 // filepath: extensions/iNaturalistGallery/iNaturalistGallery.php
 
-if ( !defined( 'MEDIAWIKI' ) ) {
-    die( "This is a MediaWiki extension and cannot be run standalone.\n" );
+if (!defined('MEDIAWIKI')) {
+    die("This is a MediaWiki extension and cannot be run standalone.\n");
 }
 
 $wgExtensionCredits['parserhook'][] = [
     'name' => 'iNaturalistGallery',
-    'author' => 'Your Name',
-    'description' => 'Displays an iNaturalist gallery based on a provisional species name.',
-    'version' => '1.0',
+    'author' => 'Matej Franceskin',
+    'description' => 'Displays an iNaturalist gallery based on a species name (standard or provisional).',
+    'version' => '1.1',
     'url' => 'https://www.mediawiki.org/wiki/Extension:iNaturalistGallery',
 ];
 
-// Register the parser hook
 $wgHooks['ParserFirstCallInit'][] = 'iNaturalistGallery::onParserFirstCallInit';
 
 class iNaturalistGallery {
-    public static function onParserFirstCallInit( Parser $parser ) {
-        // Register the <inatgallery> tag
-        $parser->setHook( 'inatgallery', [ self::class, 'renderGallery' ] );
+    private static $logFile = '/var/www/vhosts/mycomap.org/wiki/logs/inat_debug.log';
+
+    public static function onParserFirstCallInit(Parser $parser) {
+        $parser->setHook('iNaturalistGallery', [self::class, 'renderGallery']);
         return true;
     }
 
-    public static function renderGallery( $input, array $args, Parser $parser, PPFrame $frame ) {
-        // Get the species name from the tag parameter or default to the current page name
-        $speciesName = isset( $args['species'] ) ? $args['species'] : $parser->getTitle()->getText();
-        if ( empty( $speciesName ) ) {
+    private static function logDebug($message) {
+        error_log(date('[Y-m-d H:i:s] ') . $message . "\n", 3, self::$logFile);
+    }
+
+    public static function renderGallery($input, array $args, Parser $parser, PPFrame $frame) {
+        $speciesName = isset($args['species']) ? $args['species'] : $parser->getTitle()->getText();
+        if (empty($speciesName)) {
             return '<div class="error">Error: No species name provided.</div>';
         }
+
         $speciesName = str_replace('_', ' ', $speciesName);
-    
-        // Fetch observations from the iNaturalist API using Provisional Species Name
         $apiUrl = 'https://api.inaturalist.org/v1/observations';
-        $params = [
-            'order_by' => 'id',
-            'order' => 'desc',
-            'page' => 1,
-            'spam' => 'false',
-            'field:Provisional Species Name' => $speciesName,
-            'per_page' => 24,
-            'return_bounds' => 'true',
-        ];
-    
-        $queryString = http_build_query( $params );
-        $response = file_get_contents( "$apiUrl?$queryString" );
-        if ( $response === false ) {
-            return '<div class="error">Error: Unable to fetch data from iNaturalist API.</div>';
-        }
-    
-        $data = json_decode( $response, true );
-    
-        // If no results are found, fallback to searching by taxon name
-        if ( !isset( $data['results'] ) || empty( $data['results'] ) ) {
+        $foundBy = '';
+        $data = null;
+        $fieldName = 'field:Provisional Species Name'; // Default to provisional field name
+
+        // If name contains quotes it's provisional - skip standard taxonomy search
+        if (strpos($speciesName, "'") !== false || strpos($speciesName, '"') !== false) {
+            $foundBy = "Provisional Species Name";
+            // Try the iNaturalist observation field Provisional Species Name 
             $params = [
                 'order_by' => 'id',
                 'order' => 'desc',
                 'page' => 1,
                 'spam' => 'false',
-                'taxon_name' => $speciesName, // Fallback to taxon name search
+                'field:Provisional Species Name' => $speciesName,
                 'per_page' => 24,
                 'return_bounds' => 'true',
             ];
-    
-            $queryString = http_build_query( $params );
-            $response = file_get_contents( "$apiUrl?$queryString" );
-            if ( $response === false ) {
-                return '<div class="error">Error: Unable to fetch data from iNaturalist API.</div>';
+            $queryString = http_build_query($params);
+            $url = "$apiUrl?$queryString";
+
+            self::logDebug("Fallback to Provisional Species Name: '$speciesName'");
+            self::logDebug("Provisional API URL: $url");
+
+            $response = file_get_contents($url);
+            if ($response !== false) {
+                $data = json_decode($response, true);
+                if (!empty($data['results'])) {
+                    $foundBy = "Provisional Species Name";
+                    $fieldName = 'field:Provisional Species Name'; // Set the field for provisional name
+                }
             }
-    
-            $data = json_decode( $response, true );
-            if ( !isset( $data['results'] ) || empty( $data['results'] ) ) {
-                return '<div class="error">No observations found for the given species or taxon name.</div>';
+        } else {
+            // Step 1: Try to get taxon_id from the iNaturalist standard taxonomy
+            $taxonSearchUrl = 'https://api.inaturalist.org/v1/taxa?q=' . urlencode($speciesName);
+            self::logDebug("Standard taxonomy search for species: '$speciesName'");
+            self::logDebug("Taxon API URL: $taxonSearchUrl");
+
+            $taxonResponse = file_get_contents($taxonSearchUrl);
+            if ($taxonResponse !== false) {
+                $taxonData = json_decode($taxonResponse, true);
+                if (isset($taxonData['results'][0]['id'])) {
+                    $taxonId = $taxonData['results'][0]['id'];
+
+                    $params = [
+                        'order_by' => 'id',
+                        'order' => 'desc',
+                        'page' => 1,
+                        'spam' => 'false',
+                        'taxon_id' => $taxonId,
+                        'field:DNA Barcode ITS' => '',
+                        'per_page' => 24,
+                        'return_bounds' => 'true',
+                    ];
+                    $queryString = http_build_query($params);
+                    $url = "$apiUrl?$queryString";
+
+                    self::logDebug("Standard taxonomy observations search URL: $url");
+
+                    $response = file_get_contents($url);
+                    if ($response !== false) {
+                        $data = json_decode($response, true);
+                        if (!empty($data['results'])) {
+                            $foundBy = "standard taxonomy (taxon_id: $taxonId)";
+                            $fieldName = 'field:DNA Barcode ITS'; // Set the field for DNA barcode ITS
+                        }
+                    }
+                }
             }
         }
-    
-        // Generate the gallery HTML
-        $html = '<div class="inat-gallery" style="display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px;">';
-        foreach ( $data['results'] as $observation ) {
-            if ( isset( $observation['photos'][0] ) ) {
+
+        if (empty($data['results'])) {
+            return '<div class="error">No observations found for the given species name.</div>';
+        }
+
+        // Summary line
+        $count = $data['total_results'] ?? count($data['results']);
+        $summary = "<p style='font-weight:bold;'>Searched iNaturalist $foundBy for <em>$speciesName</em> with ITS sequence; total results: <strong>$count</strong>.</p>";
+
+        // Add message if more than 24 results
+        if ($count > 24) {
+            $summary .= "<p>Showing 24 results out of $count.</p>";
+        }
+
+        // Build gallery with only the first 24 results
+        $html = $summary;
+        $html .= '<div class="inat-gallery" style="display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px;">';
+
+        $limit = min(24, count($data['results']));
+        for ($i = 0; $i < $limit; $i++) {
+            $observation = $data['results'][$i];
+            if (isset($observation['photos'][0])) {
                 $photo = $observation['photos'][0];
                 $photoUrl = str_replace('square', 'small', $photo['url']);
-                $taxonName = isset( $observation['taxon']['name'] ) ? $observation['taxon']['name'] : 'Unknown Taxon';
+                $taxonName = isset($observation['taxon']['name']) ? $observation['taxon']['name'] : 'Unknown Taxon';
                 $observationUri = $observation['uri'];
-    
+
                 $html .= '<div style="text-align: center;">';
                 $html .= '<div style="width: 100%; padding-top: 100%; position: relative; overflow: hidden; border-radius: 5px;">';
                 $html .= "<img src=\"$photoUrl\" alt=\"$taxonName\" style=\"position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover;\">";
@@ -92,15 +139,25 @@ class iNaturalistGallery {
                 $html .= '</div>';
             }
         }
+
         $html .= '</div>';
 
-        // Add the link to all observations for the species
-        $speciesNameEncoded = urlencode( $speciesName );
-        $allObservationsUrl = "https://www.inaturalist.org/observations?verifiable=any&place_id=any&field:Provisional%20Species%20Name=$speciesNameEncoded";
+        // Link to full list with conditional text and field
+        $speciesNameEncoded = urlencode($speciesName);
+        $fullUrl = '';
+
+        if ($foundBy === "standard taxonomy (taxon_id: $taxonId)") {
+            $fullUrl = "https://www.inaturalist.org/observations?subview=map&taxon_id=$taxonId&field:DNA%20Barcode%20ITS=";
+            $linkText = "Sequenced iNaturalist observations for $speciesName";
+        } else {
+            $fullUrl = "https://www.inaturalist.org/observations?verifiable=any&place_id=any&$fieldName=$speciesNameEncoded";
+            $linkText = "iNaturalist observations for provisional species name $speciesName";
+        }
+
         $html .= '<div style="text-align: center; margin-top: 20px;">';
-        $html .= "<a href=\"$allObservationsUrl\" target=\"_blank\" style=\"text-decoration: none; color: #007BFF; font-weight: bold;\">All iNaturalist observations for $speciesName</a>";
+        $html .= "<a href=\"$fullUrl\" target=\"_blank\" style=\"text-decoration: none; color: #007BFF; font-weight: bold;\">$linkText</a>";
         $html .= '</div>';
-    
+
         return $html;
     }
 }

--- a/iNaturalistGallery.php
+++ b/iNaturalistGallery.php
@@ -207,22 +207,28 @@ class iNaturalistGallery {
         self::logDebug("Number of photos in regular mode: " . count($regularPhotos));
         self::logDebug("Number of photos in all photos mode: " . count($allPhotos));
 
-        // Display status texts
-        $regularStatusText = "Showing one photo from each of " . count($regularPhotos) . " observations. These observations contain a total of $totalPhotoCount photos.";
+        // Create safe, JSON-encoded JavaScript strings for use in the script
+        $regularStatusText = json_encode("Showing one photo from each of " . count($regularPhotos) . " observations. These observations contain a total of $totalPhotoCount photos.");
         
         if ($foundBy === "Provisional Species Name") {
-            $allPhotosStatusText = "Showing $totalPhotoCount photos of $speciesName.";
-            $allPhotosLinkText = "Show photos of $speciesName";
+            $safeSpeciesName = json_encode($speciesName);
+            $allPhotosStatusText = json_encode("Showing $totalPhotoCount photos of $speciesName.");
+            $allPhotosLinkText = json_encode("Show photos of $speciesName");
         } else {
-            $allPhotosStatusText = "Showing $totalPhotoCount photos of sequenced observations of $speciesName.";
-            $allPhotosLinkText = "Show photos of sequenced observations of $speciesName";
+            $safeSpeciesName = json_encode($speciesName);
+            $allPhotosStatusText = json_encode("Showing $totalPhotoCount photos of sequenced observations of $speciesName.");
+            $allPhotosLinkText = json_encode("Show photos of sequenced observations of $speciesName");
         }
+        
+        // Extract the string content (without JSON quotes) for use in HTML
+        $regularStatusTextHtml = htmlspecialchars(json_decode($regularStatusText), ENT_QUOTES);
+        $allPhotosLinkTextHtml = htmlspecialchars(json_decode($allPhotosLinkText), ENT_QUOTES);
 
         // Build gallery HTML
         $html = $summary;
         
         // Status text (changes based on current view)
-        $html .= "<p id=\"{$galleryId}_status\">$regularStatusText</p>";
+        $html .= "<p id=\"{$galleryId}_status\">$regularStatusTextHtml</p>";
         
         // Regular gallery container (one photo per observation) - visible by default
         $html .= "<div id=\"{$galleryId}_regular_container\" style=\"display: block;\">";
@@ -273,11 +279,11 @@ class iNaturalistGallery {
         $html .= "<br><br>";
         
         // Toggle buttons with more reliable onclick handlers
-        $html .= "<button id=\"{$galleryId}_show_all\" style=\"background: none; border: none; color: #007BFF; text-decoration: underline; cursor: pointer; font-weight: bold; padding: 0;\">$allPhotosLinkText</button>";
+        $html .= "<button id=\"{$galleryId}_show_all\" style=\"background: none; border: none; color: #007BFF; text-decoration: underline; cursor: pointer; font-weight: bold; padding: 0;\">$allPhotosLinkTextHtml</button>";
         $html .= "<button id=\"{$galleryId}_show_regular\" style=\"background: none; border: none; color: #007BFF; text-decoration: underline; cursor: pointer; font-weight: bold; padding: 0; display: none;\">Show one photo per observation</button>";
         $html .= '</div>';
         
-        // Better JavaScript toggle implementation
+        // Better JavaScript toggle implementation with properly encoded strings
         $parser->getOutput()->addHeadItem("
             <script type=\"text/javascript\">
             (function() {
@@ -305,7 +311,7 @@ class iNaturalistGallery {
                         allContainer.style.display = 'block';
                         showAllBtn.style.display = 'none';
                         showRegularBtn.style.display = 'inline';
-                        statusText.textContent = '$allPhotosStatusText';
+                        statusText.textContent = $allPhotosStatusText;
                         return false;
                     }
                     
@@ -316,7 +322,7 @@ class iNaturalistGallery {
                         regularContainer.style.display = 'block';
                         showRegularBtn.style.display = 'none';
                         showAllBtn.style.display = 'inline';
-                        statusText.textContent = '$regularStatusText';
+                        statusText.textContent = $regularStatusText;
                         return false;
                     }
                     


### PR DESCRIPTION
The changes update the iNaturalistGallery extension by introducing enhanced logging, and implementing more gallery rendering logic. The parser hook tag is changed to <iNaturalistGallery>. The gallery now distinguishes between provisional and standard (iNaturalist taxonomy) species names, using a two-step search strategy: it queries by "Provisional Species Name" if quotes are present, or by taxon ID (with a filter for the iNat observation field "DNA Barcode ITS") otherwise. The output includes improved error handling, logging of API requests, a dynamic summary, and a context-aware link at the gallery's end.

Ddds a link to show all photos and improves the logic used to find photos on iNaturalist.

Protects against JavaScript injection by properly escaping special characters like quotes and backslashes in user-provided content, ensuring that the JavaScript will run correctly and safely even if the species name contains crazy characters.